### PR TITLE
fix: simplify auth banner text

### DIFF
--- a/app/src/components/TerminalView.tsx
+++ b/app/src/components/TerminalView.tsx
@@ -31,7 +31,7 @@ export function TerminalView() {
       </div>
       {authUrl && (
         <div className="auth-banner">
-          <span className="auth-label">&#x1f511; Authentication required</span>
+          <span className="auth-label">auth required</span>
           <a className="auth-link" href={authUrl} target="_blank" rel="noopener noreferrer">
             Open login &rarr;
           </a>


### PR DESCRIPTION
## Summary
- Changed the auth banner label from "🔑 Authentication required" to "auth required"

## Test plan
- [ ] Verify the auth banner displays "auth required" when an auth URL is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)